### PR TITLE
fixed reading wrong input on Windows and updated install.sh

### DIFF
--- a/cmd/client/connection.go
+++ b/cmd/client/connection.go
@@ -15,13 +15,14 @@ import (
 //
 // If there is no error after pinging the DB, this function takes
 // input(cmds) to execute on the DB specified by the user.
-// To see available cmds, type; > help
+// To see available cmds;
+// 		> help
 func (c *DbClient) OpenConnection() error {
 	db, err := sql.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:%s)/%s", c.ConnInfo.User, c.ConnInfo.Password, c.ConnInfo.HostAddr, c.ConnInfo.Port, c.ConnInfo.DbName))
-
 	if err != nil {
 		return err
 	}
+
 	c.db = db
 	defer db.Close()
 	if err := db.Ping(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,5 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
 	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 // indirect
+	golang.org/x/term v0.0.0-20201117132131-f5c789dd3221
 )

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-cd ./cmd/cli || exit
+cd ./cmd || exit
 go build -o $GOPATH/bin/rsql


### PR DESCRIPTION
- On Windows, user inputs include '\r' as well as '\n'. Trim function of connection.go updated to handle these inputs.
- On Windows, `terminal.ReadPassword` from [`golang.org/x/crypto/ssh/terminal`](https://pkg.go.dev/golang.org/x/crypto/ssh/terminal) causes panic. It switched to `term.ReadPassword` from [`golang.org/x/term`](https://pkg.go.dev/golang.org/x/term) for Windows. Linux version stays same.
 - Updated install.sh since main app file (cmd/app.go) has new location.
